### PR TITLE
Use extractors of vendor workflow and not vendor reference link workflow

### DIFF
--- a/vendors/tasks/extractMergeVendorsMSDB.json
+++ b/vendors/tasks/extractMergeVendorsMSDB.json
@@ -16,5 +16,5 @@
   ],
   "enhancementMappings": [],
   "mergeStrategy": "MERGE",
-  "streamSource": "{{mod-data-extractor-internal}}/extractors/11192db4-57c5-4d6e-bef6-518f728934a7/run"
+  "streamSource": "{{mod-data-extractor-internal}}/extractors/d12ef318-0044-11ea-8d71-362b9e155667/run"
 }

--- a/vendors/tasks/extractVendorsAMDB.json
+++ b/vendors/tasks/extractVendorsAMDB.json
@@ -7,5 +7,5 @@
   "enhancementComparisons": [],
   "enhancementMappings": [],
   "mergeStrategy": "CONCAT",
-  "streamSource": "{{mod-data-extractor-internal}}/extractors/c581ccb4-ec0c-49a3-b4b4-50cb9116a88b/run"
+  "streamSource": "{{mod-data-extractor-internal}}/extractors/c6b5a9b8-0044-11ea-8d71-362b9e155667/run"
 }


### PR DESCRIPTION
Resolved #39 

The regression was actually caused by the vendor workflow using the same extractor as the vendor reference link workflow. After simplifying the vendor reference link workflow, vendor workflow broke.